### PR TITLE
Add rule to prevent use of global 'event' variable

### DIFF
--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -32,5 +32,8 @@ module.exports = {
     'valid-jsdoc': 2,                 // http://eslint.org/docs/rules/valid-jsdoc
     'valid-typeof': 2,                // http://eslint.org/docs/rules/valid-typeof
     'no-unexpected-multiline': 2,     // http://eslint.org/docs/rules/no-unexpected-multiline
+    'no-restricted-globals': [        // http://eslint.org/docs/rules/no-restricted-globals
+      2, 'event'
+    ]
   }
 };


### PR DESCRIPTION
The `"env": "browser"` option, adds `event` as a global variable (for some reason - see https://github.com/eslint/eslint/issues/3964).

This opens up the possibility of depending on the global variable by mistake, example:

```javascript
element.addEventListener('keydown', () => {
  if (event.keyCode === 13) { // no linting error
    // ...
  }
});
```

... where the intention clearly would be to have an `event` argument in the event callback.

This PR adds a rule that prevents using the global `event` variable.