### PR TITLE
Feature max-lines

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -47,6 +47,13 @@ module.exports = {
     'lines-around-comment': 0,        // http://eslint.org/docs/rules/lines-around-comment
     'max-depth': [2, 4],              // http://eslint.org/docs/rules/max-depth
     'max-len': [0, 80],               // http://eslint.org/docs/rules/max-len
+    'max-lines': [                    // http://eslint.org/docs/rules/max-lines
+      1, {
+        max: 500,
+        skipBlankLines: false,
+        skipComments: false
+      }
+    ],
     'max-nested-callbacks': [2, 3],   // http://eslint.org/docs/rules/max-nested-callbacks
     'max-params': [2, 3],             // http://eslint.org/docs/rules/max-params
     'max-statements': [0, 2],         // http://eslint.org/docs/rules/max-statements


### PR DESCRIPTION
Added max-lines stylistics to raise an warning when we have a file that has more than 500 loc.
This does not skip blank lines or comments which are default set to skip, any objection or changes please tell .

http://eslint.org/docs/rules/max-lines

#41 