### PR TITLE
Change key-spacing mode to minimum, not strict

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -38,7 +38,8 @@ module.exports = {
     'key-spacing': [                  // http://eslint.org/docs/rules/key-spacing
       2, {
         beforeColon: false,
-        afterColon: true
+        afterColon: true,
+        mode: 'minimum'
       }
     ],
     'keyword-spacing': 0,             // http://eslint.org/docs/rules/keyword-spacing


### PR DESCRIPTION
So that object literals may have aligned columns, e.g.:
```
const product = {
    pa:    action,                 // Product action
    pal:   payload.list,           // Product action list
    pr1id: payload.id,
    pr1nm: payload.name,
    pr1br: `prf:${payload.brand}`, // Product brand prefixed by "prf:"
    pr1va: payload.variant,
    pr1ps: payload.position
  };
```